### PR TITLE
critical fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:18-jdk-slim
+FROM openjdk:21-jdk-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         - IMG_TYPE=google_apis
     ports:
       - 5554:5554
-      - 5555:5555
+      - 127.0.0.1:5555:5555
     environment:
       - DISABLE_ANIMATION=false
       - DISABLE_HIDDEN_POLICY=true
@@ -37,7 +37,7 @@ services:
         - IMG_TYPE=google_apis
     ports:
       - 5554:5554
-      - 5555:5555
+      - 127.0.0.1:5555:5555
     environment:
       - DISABLE_ANIMATION=false
       - DISABLE_HIDDEN_POLICY=true
@@ -71,7 +71,7 @@ services:
         - IMG_TYPE=google_apis_playstore
     ports:
       - 5554:5554
-      - 5555:5555
+      - 127.0.0.1:5555:5555
     environment:
       - DISABLE_ANIMATION=false
       - DISABLE_HIDDEN_POLICY=true

--- a/scripts/emulator-monitoring.sh
+++ b/scripts/emulator-monitoring.sh
@@ -32,16 +32,20 @@ function wait_for_boot() {
   update_state "ANDROID_BOOTING"
 
   # Waiting for the ADB server to start.
-  while [ -n "$(adb wait-for-device > /dev/null)" ]; do
-    adb wait-for-device
-    sleep 1
-  done
-  
+  adb wait-for-device
+
   # Waiting for the boot sequence to be completed.
+  TIMEOUT=300
+  COUNTER=0
   COMPLETED=$(adb shell getprop sys.boot_completed | tr -d '\r')
   while [ "$COMPLETED" != "1" ]; do
+    if [ $COUNTER -ge $TIMEOUT ]; then
+      echo "Error: Emulator failed to boot within $TIMEOUT seconds."
+      exit 1
+    fi
     COMPLETED=$(adb shell getprop sys.boot_completed | tr -d '\r')
     sleep 5
+    COUNTER=$((COUNTER + 5))
   done
   sleep 1
   if [ "$DISABLE_ANIMATION" = "true" ]; then


### PR DESCRIPTION


### 1. Critical Security Vulnerability: Unrestricted ADB Exposure
* **Location:** `docker-compose.yml` (lines 11-12) and `scripts/start-emulator.sh` (line 23).
* **Issue:** The default configuration maps the ADB port `5555:5555` on `0.0.0.0` (all interfaces).
* **Risk:** If a user sets `SKIP_AUTH=true`, this exposes an unauthenticated root shell to the entire network.
* **Recommendation:** Change the default port mapping to bind only to localhost (`127.0.0.1:5555:5555`).

### 2. Missing Safeguard: Infinite Boot Loop
* **Location:** `scripts/emulator-monitoring.sh` (lines 42-45).
* **Issue:** The `while [ "$COMPLETED" != "1" ]` loop waits indefinitely for `sys.boot_completed`.
* **Risk:** If the emulator hangs due to KVM or architecture issues, the container hangs forever, consuming resources.
* **Recommendation:** Implement a timeout counter (e.g., 300 seconds) to force an exit if the device fails to boot.


### 3. Dependency: EOL Java Version
* **Location:** `Dockerfile` (line 1).
* **Issue:** Using `openjdk:18-jdk-slim`. JDK 18 reached End-of-Life in September 2022.
* **Recommendation:** Upgrade to an LTS version like `openjdk:21-jdk-slim` or `openjdk:17-jdk-slim`.

### 4. Documentation Mismatch
* **Location:** `README.md` vs `Dockerfile`.
* **Issue:** README claims JRE 11, but Dockerfile installs JDK 18. This causes confusion during debugging.

### 5. Flawed Wait Logic
* **Location:** `scripts/emulator-monitoring.sh` (lines 35-38).
* **Code:**
  ```bash
  while [ -n "$(adb wait-for-device > /dev/null)" ]; do ... done