### PR TITLE
move from openjdk to eclipse-temurin image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:25
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
The openjdk images are deprecated, so changing to `eclipse-temurin` what seems to work fine