### PR TITLE
Add noVNC browser access and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,windows,powershell
+android_avd

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update && apt install -y curl \
 	libxkbcommon-dev libgbm-dev libasound-dev libnss3 \
 	libxcursor1 libpulse-dev libxshmfence-dev \
 	xauth xvfb x11vnc fluxbox wmctrl libdbus-glib-1-2 socat \
-	virt-manager
+	virt-manager novnc websockify
 
 
 # Docker labels.
@@ -56,7 +56,7 @@ WORKDIR /opt
 
 # Exposing the Android emulator console port
 # and the ADB port.
-EXPOSE 5554 5555
+EXPOSE 5554 5555 5900 6080
 
 # Initializing the required directories.
 RUN mkdir /root/.android/ && \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -18,9 +18,13 @@ RUN apt update -y && \
   virt-manager \
   libvulkan1 \
   xvfb \
+  x11vnc \
+  fluxbox \
   libgl1-mesa-glx \
   libgl1-mesa-dri \
   socat \
+  novnc \
+  websockify \
   htop \
   iproute2 && \
   rm -rf /var/lib/apt/lists/*
@@ -59,7 +63,7 @@ WORKDIR /opt
 
 # Exposing the Android emulator console port
 # and the ADB port.
-EXPOSE 5554 5555
+EXPOSE 5554 5555 5900 6080
 
 # Initializing the required directories.
 RUN mkdir /root/.android/ && \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 # docker-android
 > A minimal and customizable Docker image running the Android emulator as a service.
 
+中文: [README.zh-CN.md](README.zh-CN.md)
+
 [![Docker Image CI](https://github.com/HQarroum/docker-android/actions/workflows/docker-image.yml/badge.svg)](https://github.com/HQarroum/docker-android/actions/workflows/docker-image.yml)
 [![DeepSource](https://deepsource.io/gh/HQarroum/docker-android.svg/?label=active+issues&show_trend=true&token=JTfGSHolIiMj0WNfv2ES0I6X)](https://deepsource.io/gh/HQarroum/docker-android/?ref=repository-badge)
 ![Docker Pulls](https://img.shields.io/docker/pulls/halimqarroum/docker-android)
@@ -27,6 +29,7 @@ Current version: **1.1.0**
 - Port-forwarding of emulator and ADB on the container network interface built-in.
 - Emulator images are wiped each time the emulator re-starts.
 - Runs headless, suitable for CI farms. Compatible with [`scrcpy`](https://github.com/Genymobile/scrcpy) to remotely control the Android screen.
+- Optional browser access through noVNC for viewing and interacting with the emulator without a local GUI client.
 
 ## 🔰 Description
 
@@ -50,6 +53,8 @@ with docker-compose:
 ```bash
 docker compose up android-emulator
 ```
+
+The default compose service also exposes noVNC on `127.0.0.1:6080`.
 
 or with GPU acceleration
 ```bash
@@ -110,6 +115,34 @@ Additionally, you can use [`scrcpy`](https://github.com/Genymobile/scrcpy) to co
 scrcpy
 ```
 
+### Access the emulator with noVNC
+
+The compose services in this repository can also publish the emulator window through noVNC. This avoids installing a local GUI client on the host and is useful when you only need a browser.
+
+Start one of the bundled services:
+
+```bash
+docker compose up --build android-emulator
+```
+
+or
+
+```bash
+docker compose up --build android-emulator-cuda
+```
+
+Once the container is running and the emulator has booted, open:
+
+```text
+http://127.0.0.1:6080/vnc.html
+```
+
+Notes:
+
+- `5555` remains available for `adb connect 127.0.0.1:5555`.
+- The compose file enables noVNC with `ENABLE_NOVNC=true`.
+- The virtual display size can be adjusted with `DISPLAY_WIDTH`, `DISPLAY_HEIGHT`, and `DISPLAY_DPI`.
+
 <br />
 <table>
   <tr>
@@ -159,6 +192,18 @@ DISABLE_HIDDEN_POLICY=false
 
 #### Skip adb authentication
 SKIP_AUTH=true
+
+#### Enable noVNC browser access
+ENABLE_NOVNC=false
+
+#### Virtual display width for noVNC
+DISPLAY_WIDTH=1080
+
+#### Virtual display height for noVNC
+DISPLAY_HEIGHT=1920
+
+#### Virtual display DPI for noVNC
+DISPLAY_DPI=160
 
 #### Memory for emulator
 MEMORY=8192

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,167 @@
+# docker-android 中文说明
+
+一个可定制的 Docker Android 模拟器镜像。容器内运行 Android Emulator，并通过 ADB、`scrcpy` 或 noVNC 对外访问。
+
+English version: [README.md](README.md)
+
+## 功能
+
+- 在容器内运行 Android 模拟器
+- 支持 KVM 硬件虚拟化
+- 支持按构建参数选择 Android API、镜像类型和架构
+- 暴露 ADB 端口，宿主机可直接连接
+- 支持宿主机通过 `scrcpy` 控制模拟器
+- 支持通过 noVNC 在浏览器中查看和操作模拟器
+
+## 使用方式
+
+默认构建会安装 Android SDK、platform-tools、emulator 和目标 system image。
+
+使用普通版本：
+
+```bash
+docker compose up --build android-emulator
+```
+
+使用 GPU 版本：
+
+```bash
+docker compose up --build android-emulator-cuda
+```
+
+使用 GPU + Play Store 版本：
+
+```bash
+docker compose up --build android-emulator-cuda-store
+```
+
+如果只构建镜像：
+
+```bash
+docker build -t android-emulator .
+```
+
+## ADB Key
+
+如果使用 `google_apis_playstore` 镜像，建议让客户端和模拟器使用同一组 ADB key。
+
+生成方式：
+
+```bash
+adb keygen adbkey
+```
+
+把生成的 `adbkey` 和 `adbkey.pub` 放到 `./keys/` 目录下。
+
+## 运行容器
+
+示例：
+
+```bash
+docker run -it --rm --device /dev/kvm -p 5555:5555 android-emulator
+```
+
+如果需要持久化 AVD 数据：
+
+```bash
+docker run -it --rm --device /dev/kvm -p 5555:5555 -v ~/android_avd:/data android-emulator
+```
+
+当前仓库默认使用 compose，并额外暴露 noVNC 端口 `6080`。
+
+## 通过 ADB 访问
+
+容器启动后，内部 ADB server 会自动启动。模拟器启动完成后，可在宿主机执行：
+
+```bash
+adb connect 127.0.0.1:5555
+```
+
+## 通过 scrcpy 访问
+
+如果宿主机已经安装 `scrcpy`，在完成 `adb connect` 后直接执行：
+
+```bash
+scrcpy
+```
+
+这种方式适合本地开发机直接控制模拟器。
+
+## 通过 noVNC 浏览器访问
+
+本仓库已经在 `docker-compose.yml` 中启用了 noVNC。启动容器后，可以直接用浏览器访问容器中的模拟器窗口。
+
+启动：
+
+```bash
+docker compose up --build android-emulator
+```
+
+浏览器访问：
+
+```text
+http://127.0.0.1:6080/vnc.html
+```
+
+说明：
+
+- noVNC 访问不需要本机安装 `scrcpy`
+- 宿主机仍然可以同时使用 `adb connect 127.0.0.1:5555`
+- 如果需要调整浏览器中显示的分辨率，可修改 `DISPLAY_WIDTH`、`DISPLAY_HEIGHT`、`DISPLAY_DPI`
+
+## 当前 compose 默认参数
+
+当前仓库的 `docker-compose.yml` 默认包含这些配置：
+
+- `DISABLE_ANIMATION=true`
+- `DISABLE_HIDDEN_POLICY=true`
+- `SKIP_AUTH=false`
+- `ENABLE_NOVNC=true`
+- `DISPLAY_WIDTH=1080`
+- `DISPLAY_HEIGHT=1920`
+- `DISPLAY_DPI=160`
+- `MEMORY=16384`
+- `CORES=16`
+
+## 可配置变量
+
+- `DISABLE_ANIMATION`
+  是否关闭系统动画
+- `DISABLE_HIDDEN_POLICY`
+  是否关闭 hidden API policy
+- `SKIP_AUTH`
+  是否跳过 ADB 认证
+- `ENABLE_NOVNC`
+  是否启用 noVNC 浏览器访问
+- `DISPLAY_WIDTH`
+  noVNC 虚拟显示宽度
+- `DISPLAY_HEIGHT`
+  noVNC 虚拟显示高度
+- `DISPLAY_DPI`
+  noVNC 虚拟显示 DPI
+- `MEMORY`
+  模拟器内存大小
+- `CORES`
+  模拟器 CPU 核数
+- `EXTRA_FLAGS`
+  额外传给 emulator 的参数
+
+## 自定义镜像
+
+可以通过构建参数指定 API、镜像类型和架构。
+
+示例：
+
+```bash
+docker build \
+  --build-arg API_LEVEL=28 \
+  --build-arg IMG_TYPE=google_apis_playstore \
+  --build-arg ARCHITECTURE=x86 \
+  --tag android-emulator .
+```
+
+## 说明
+
+- noVNC 适合“只想通过浏览器查看和操作模拟器”的场景
+- `scrcpy` 适合“本机需要更直接的桌面控制体验”的场景
+- 如果追求性能，优先保证 `/dev/kvm` 可用，并尽量把 AVD 数据放在 Linux 原生文件系统而不是慢速挂载盘上

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
     ports:
       - 5554:5554
       - 127.0.0.1:5555:5555
+      - 127.0.0.1:6080:6080
     environment:
-      - DISABLE_ANIMATION=false
+      - DISABLE_ANIMATION=true
       - DISABLE_HIDDEN_POLICY=true
       - SKIP_AUTH=false
+      - ENABLE_NOVNC=true
+      - DISPLAY_WIDTH=1080
+      - DISPLAY_HEIGHT=1920
+      - DISPLAY_DPI=160
       #- ANDROID_ADB_SERVER_ADDRESS=host.docker.internal
       - MEMORY=16384
       - CORES=16
@@ -40,10 +45,15 @@ services:
     ports:
       - 5554:5554
       - 127.0.0.1:5555:5555
+      - 127.0.0.1:6080:6080
     environment:
-      - DISABLE_ANIMATION=false
+      - DISABLE_ANIMATION=true
       - DISABLE_HIDDEN_POLICY=true
       - SKIP_AUTH=false
+      - ENABLE_NOVNC=true
+      - DISPLAY_WIDTH=1080
+      - DISPLAY_HEIGHT=1920
+      - DISPLAY_DPI=160
       #- ANDROID_ADB_SERVER_ADDRESS=host.docker.internal
       - MEMORY=16384
       - CORES=16
@@ -74,10 +84,15 @@ services:
     ports:
       - 5554:5554
       - 127.0.0.1:5555:5555
+      - 127.0.0.1:6080:6080
     environment:
-      - DISABLE_ANIMATION=false
+      - DISABLE_ANIMATION=true
       - DISABLE_HIDDEN_POLICY=true
       - SKIP_AUTH=false
+      - ENABLE_NOVNC=true
+      - DISPLAY_WIDTH=1080
+      - DISPLAY_HEIGHT=1920
+      - DISPLAY_DPI=160
       #- ANDROID_ADB_SERVER_ADDRESS=host.docker.internal
       - MEMORY=16384
       - CORES=16

--- a/scripts/start-emulator.sh
+++ b/scripts/start-emulator.sh
@@ -11,7 +11,24 @@ ADB_PORT=5555
 OPT_MEMORY=${MEMORY:-8192}
 OPT_CORES=${CORES:-4}
 OPT_SKIP_AUTH=${SKIP_AUTH:-true}
+OPT_ENABLE_NOVNC=${ENABLE_NOVNC:-false}
+OPT_DISPLAY_WIDTH=${DISPLAY_WIDTH:-1080}
+OPT_DISPLAY_HEIGHT=${DISPLAY_HEIGHT:-1920}
+OPT_DISPLAY_DPI=${DISPLAY_DPI:-160}
 AUTH_FLAG=
+EMULATOR_WINDOW_FLAG="-no-window"
+
+function start_remote_desktop() {
+  export DISPLAY=":0.0"
+
+  Xvfb "$DISPLAY" -screen 0 "${OPT_DISPLAY_WIDTH}x${OPT_DISPLAY_HEIGHT}x24" -dpi "$OPT_DISPLAY_DPI" -nolisten tcp &
+  fluxbox >/tmp/fluxbox.log 2>&1 &
+  x11vnc -display "$DISPLAY" -forever -shared -rfbport 5900 -nopw >/tmp/x11vnc.log 2>&1 &
+
+  if [ "$OPT_ENABLE_NOVNC" == "true" ]; then
+    /usr/share/novnc/utils/novnc_proxy --vnc localhost:5900 --listen 6080 >/tmp/novnc.log 2>&1 &
+  fi
+}
 # Start ADB server by listening on all interfaces.
 echo "Starting the ADB server ..."
 adb -a -P 5037 server nodaemon &
@@ -50,9 +67,16 @@ fi
 if [ "$GPU_ACCELERATED" == "true" ]; then
   export DISPLAY=":0.0"
   export GPU_MODE="host"
-  Xvfb "$DISPLAY" -screen 0 1920x1080x16 -nolisten tcp &
 else
   export GPU_MODE="swiftshader_indirect"
+fi
+
+if [ "$OPT_ENABLE_NOVNC" == "true" ] || [ "$GPU_ACCELERATED" == "true" ]; then
+  start_remote_desktop
+fi
+
+if [ "$OPT_ENABLE_NOVNC" == "true" ]; then
+  EMULATOR_WINDOW_FLAG=
 fi
 
 # Asynchronously write updates on the standard output
@@ -74,7 +98,7 @@ emulator \
   -cores "$OPT_CORES" \
   -ranchu \
   $AUTH_FLAG \
-  -no-window \
+  $EMULATOR_WINDOW_FLAG \
   -no-snapshot \
   $EXTRA_FLAGS || update_state "ANDROID_STOPPED"
 


### PR DESCRIPTION
- expose the emulator window through Xvfb, x11vnc, and noVNC
- keep ADB and local scrcpy access available
- document browser-based noVNC usage in README
- add a Chinese README for setup and access instructions
<img width="2559" height="1368" alt="image" src="https://github.com/user-attachments/assets/1c0b7d33-48e8-47cc-a849-db48c79d6715" />
